### PR TITLE
Update 2016-07-29-phalcon-3-0-0-released.md

### DIFF
--- a/data/posts/2016/07/2016-07-29-phalcon-3-0-0-released.md
+++ b/data/posts/2016/07/2016-07-29-phalcon-3-0-0-released.md
@@ -947,8 +947,6 @@ $validator->add(
 #### DOCUMENTATION
 &bull; Added Indonesian translation [GPR:840]
 
-&bull; Added `Phalcon\Cli\DispatcherInterface`, `Phalcon\Cli\TaskInterface`, `Phalcon\Cli\RouterInterface` and `Phalcon\Cli\Router\RouteInterface`.
-
 #### VARIOUS
 &bull; Added `Phalcon\Assets\Manager::exists()` to check if collection exists
 


### PR DESCRIPTION
Removed the "&bull; Added `Phalcon\Cli\DispatcherInterface`, `Phalcon\Cli\TaskInterface`, `Phalcon\Cli\RouterInterface` and `Phalcon\Cli\Router\RouteInterface`." from Documentation, because is from Interfaces section