### PR TITLE
Remove Indonesian translation

### DIFF
--- a/data/posts/2016/07/2016-07-29-phalcon-3-0-0-released.md
+++ b/data/posts/2016/07/2016-07-29-phalcon-3-0-0-released.md
@@ -943,9 +943,6 @@ $validator->add(
 
 &bull; Added `Phalcon\Cli\DispatcherInterface`, `Phalcon\Cli\TaskInterface`, `Phalcon\Cli\RouterInterface` and `Phalcon\Cli\Router\RouteInterface`.
 
-#### DOCUMENTATION
-&bull; Added Indonesian translation [GPR:840]
-
 #### VARIOUS
 &bull; Added `Phalcon\Assets\Manager::exists()` to check if collection exists
 


### PR DESCRIPTION
Bahasa Indonesia (Indonesian) is my native language. I suggest to remove this information because it's completely not ready.

- Wrong pull link. Link https://github.com/phalcon/cphalcon/pull/840 was not related to Indonesian documentation.
- Documentation in Indonesian https://docs.phalconphp.com/id/latest/index.html produces HTTP 404 Error
- Example: https://github.com/phalcon/docs/blob/master/id/api/Phalcon_Tag.rst is still in English.

I also will make PR to remove Indonesian link in Phalcon documentation. I saw it's only "initial", but actually nothing is translated.