### PR TITLE
FIXED wrong link repo for Indonesian translation

### DIFF
--- a/data/posts/2016/07/2016-07-29-phalcon-3-0-0-released.md
+++ b/data/posts/2016/07/2016-07-29-phalcon-3-0-0-released.md
@@ -944,7 +944,7 @@ $validator->add(
 &bull; Added `Phalcon\Cli\DispatcherInterface`, `Phalcon\Cli\TaskInterface`, `Phalcon\Cli\RouterInterface` and `Phalcon\Cli\Router\RouteInterface`.
 
 #### DOCUMENTATION
-&bull; Added Indonesian translation [GPR:840]
+&bull; Added Indonesian translation [#840](https://github.com/phalcon/docs/pull/840)
 
 #### VARIOUS
 &bull; Added `Phalcon\Assets\Manager::exists()` to check if collection exists


### PR DESCRIPTION
Added Indonesian translation should be in docs repo not cphalcon
