### PR TITLE
Fix #350 - Update meta: Twitter/og/Description

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,5 +1,7 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.app.name }} – {{ site.app.description }}{% endif %}</title>
 
+    {% assign page_description = page.excerpt | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip |  truncatewords: 30 %}
+
     <meta name="viewport" content="width=device-width">
     <meta name="MobileOptimized" content="320"/>
     <meta name="HandheldFriendly" content="true"/>
@@ -19,7 +21,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.app.name }} – {{ site.app.description }}{% endif %}">
     {% if page.excerpt %}
-    <meta property="og:description" content="{{ page.excerpt| strip_html }}" />
+    <meta property="og:description" content="{{ page_description }}" />
     {% else %}
     <meta property="og:description" content="{{ site.app.description }}">
     {% endif %}
@@ -29,13 +31,12 @@
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:site_name" content="{{ site.app.name }}">
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{{ site.app.name }}">
+    <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.app.name }} – {{ site.app.description }}{% endif %}">
     {% if page.excerpt %}
-    <meta name="twitter:description" content="{{ page.excerpt| strip_html }}" />
+    <meta name="twitter:description" content="{{ page_description }}" />
     {% else %}
     <meta name="twitter:description" content="{{ site.app.description }}">
     {% endif %}


### PR DESCRIPTION
Hi!
I've just seen this issue : https://github.com/phalcon/blog/issues/350.
So I fixed the problem with description and return line. It's little barbaric, but it's works. Here is my beautiful source : https://stackoverflow.com/questions/45147948/how-to-strip-newlines-in-jekyll.
And I put the correct title in Twitter title meta.
I built the blog on my local computer and it works well.
